### PR TITLE
Fix run.py example

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,44 +1,22 @@
 import torch
-from transformers import AutoTokenizer
-from modeling_cocom import COCOM, COCOMConfig
+from transformers import AutoModel
 
-# Step 1: Define the configuration and initialize the model
-config = COCOMConfig(
-    decoder_model_name="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-    compr_model_name="bert-base-uncased",
-    compr_rates=[64],
-    compr_linear_type="concat",
-    quantization="no",
-    generation_top_k=1,
-    lora=False,
-    attn_implementation=None  # Explicitly disable Flash Attention
-)
-
-# Step 2: Setup device and model
+# Load a pretrained checkpoint and move it to the available device
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-model = COCOM(config).to(device)
+model = AutoModel.from_pretrained(
+    "cocom-v0-light-16-mistral-7b", trust_remote_code=True
+).to(device)
 model.eval()
 
-# Step 3: Load tokenizers
-encoder_tokenizer = AutoTokenizer.from_pretrained(config.compr_model_name)
-decoder_tokenizer = AutoTokenizer.from_pretrained(config.decoder_model_name)
+# Provide a single context and question
+contexts = [["Rome is the capital of Italy."]]
+questions = ["What is the capital of Italy?"]
 
-# Step 4: Prepare input question
-question = "What is the capital of Italy?"
-enc = encoder_tokenizer(question, return_tensors="pt", padding=True, truncation=True).to(device)
-enc_input_ids = enc["input_ids"]
-enc_attention_mask = enc["attention_mask"]
-
-# Step 5: Generate answer from the model
+# Generate the answer using the helper that prepares inputs automatically
 with torch.no_grad():
-    generated = model.generate(
-        enc_input_ids=enc_input_ids,
-        enc_attention_mask=enc_attention_mask,
-        max_new_tokens=32,
-        do_sample=False  # Greedy decoding
+    answers = model.generate_from_text(
+        contexts=contexts, questions=questions, max_new_tokens=32
     )
 
-# Step 6: Decode and print result
-answer = decoder_tokenizer.batch_decode(generated, skip_special_tokens=True)[0]
-print("Question:", question)
-print("Answer:", answer)
+print("Question:", questions[0])
+print("Answer:", answers[0])


### PR DESCRIPTION
## Summary
- update example run script to load a pretrained checkpoint
- call `generate_from_text` instead of passing keyword arguments

## Testing
- `python -m py_compile run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602c1e28b483248a3ffa30ec9de927