### PR TITLE
Add reward metric for compression bandit

### DIFF
--- a/measures.py
+++ b/measures.py
@@ -1,0 +1,24 @@
+from typing import List
+from rouge import Rouge
+import evaluate
+
+from metrics import compute_rouge_scores
+
+# Pre-load metrics
+rouge = Rouge()
+bertscore = evaluate.load("bertscore")
+
+
+def compute_bertscore(predictions: List[str], references: List[str]) -> float:
+    """Return average F1 BERTScore for predictions vs references."""
+    scores = bertscore.compute(predictions=predictions, references=references, lang="en")
+    return sum(scores["f1"]) / len(scores["f1"])
+
+
+def reward(predictions: List[str], references: List[str], compression_rate: int,
+           alpha: float = 0.5, beta: float = 0.5, gamma: float = 0.1) -> float:
+    """Compute combined reward used for bandit training."""
+    bert_f1 = compute_bertscore(predictions, references)
+    rouge_l = compute_rouge_scores(rouge, predictions, references)["Rouge-L"]
+    compression_penalty = 1.0 / float(compression_rate)
+    return alpha * bert_f1 + beta * rouge_l - gamma * compression_penalty

--- a/train_cmab.py
+++ b/train_cmab.py
@@ -3,14 +3,14 @@ import os
 import math
 import pickle
 import matplotlib.pyplot as plt
-from rouge import Rouge
+from measures import reward as compute_reward
 import datasets
 import torch
 from torch.utils.data import DataLoader
 
 from modeling_cocom import COCOM
 from cmab_agent import CompressionBanditAgent, batch_entropy
-from metrics import exact_match_score,compute_rouge_scores
+from metrics import exact_match_score
 from utils import prepare_auto_encoding
 
 
@@ -59,8 +59,6 @@ def main():
 
     # 📈 To store rewards for plotting
     rewards_history = []
-    rouge=Rouge()
-
     for rate in model.compr_rates:
         print(f"\n🔵 Compression Rate: {rate}")
         prepped = dataset.map(
@@ -94,11 +92,9 @@ def main():
 
             entropies = batch_entropy(batch["enc_input_ids"].cpu(), batch["enc_attention_mask"].cpu())
             for ent, pred, gold in zip(entropies, preds, texts):
-                acc = compute_rouge_scores(rouge,[pred], [gold])
-                acc=acc['Rouge-1']
-                reward = acc * math.sqrt(rate)
-                agent.update(ent, rate, reward)
-                batch_rewards.append(reward)
+                r = compute_reward([pred], [gold], rate)
+                agent.update(ent, rate, r)
+                batch_rewards.append(r)
 
             # Print progress every 50 steps
             if (idx + 1) % 2 == 0:


### PR DESCRIPTION
## Summary
- add `measures.py` implementing a reward metric using BERTScore and ROUGE-L with a compression penalty
- update `train_cmab.py` to use the new reward when training the contextual bandit

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882679102dc8324a2327c3930c81f52