### PR TITLE
Handle multi-rate decoder inputs in data loaders

### DIFF
--- a/modeling_cocom.py
+++ b/modeling_cocom.py
@@ -253,39 +253,57 @@ class COCOM(PreTrainedModel):
     def forward(self,
                 enc_input_ids: torch.LongTensor = None,
                 enc_attention_mask: torch.LongTensor = None,
-                dec_input_ids: torch.LongTensor = None,
-                dec_attention_mask: torch.LongTensor = None,
-                labels: torch.LongTensor = None):
+                dec_input_ids = None,
+                dec_attention_mask = None,
+                labels = None):
 
         # Get compressed embeddings for all rates
         if self.compr:
-
             all_compressed_embs = self.compr(enc_input_ids, enc_attention_mask)
         else:
             all_compressed_embs = [self.compr_decoder(enc_input_ids, enc_attention_mask)]
 
+        # Prepare decoder inputs for each rate
+        if isinstance(dec_input_ids, dict):
+            def _get(d, k):
+                return d.get(k, d.get(str(k)))
+
+            dec_ids_list = [_get(dec_input_ids, r) for r in self.config.compr_rates]
+            dec_mask_list = [_get(dec_attention_mask, r) for r in self.config.compr_rates]
+            label_list = (
+                [_get(labels, r) for r in self.config.compr_rates]
+                if labels is not None
+                else [None] * len(dec_ids_list)
+            )
+        elif isinstance(dec_input_ids, (list, tuple)):
+            dec_ids_list = list(dec_input_ids)
+            dec_mask_list = list(dec_attention_mask)
+            label_list = list(labels) if labels is not None else [None] * len(dec_ids_list)
+        else:
+            dec_ids_list = [dec_input_ids] * len(all_compressed_embs)
+            dec_mask_list = [dec_attention_mask] * len(all_compressed_embs)
+            label_list = [labels] * len(all_compressed_embs)
 
         total_loss = 0
         all_logits = []
 
         # Process each compression rate
-        for compressed_embs in all_compressed_embs:
+        for compressed_embs, dec_ids, dec_mask, lab in zip(all_compressed_embs, dec_ids_list, dec_mask_list, label_list):
             indices = range(0, enc_input_ids.size(0) + 1, self.generation_top_k)
-            inputs_embeds = self.replace_embeddings(compressed_embs, dec_input_ids, indices)
+            inputs_embeds = self.replace_embeddings(compressed_embs, dec_ids, indices)
 
             if (self.training_form == "compressor") and (self.compr is None):
                 inputs_embeds = inputs_embeds.detach()
 
             decoder_outputs = self.decoder(
                 inputs_embeds=inputs_embeds,
-                attention_mask=dec_attention_mask,
-                labels=labels
+                attention_mask=dec_mask,
+                labels=lab,
             )
 
             total_loss += decoder_outputs.loss
             all_logits.append(decoder_outputs.logits)
-        #print(f"Number of rates: {len(all_compressed_embs)}")
-        # Average the loss across all compression rates
+
         avg_loss = total_loss / len(all_compressed_embs)
 
         return {"loss": avg_loss, "logits": all_logits}  # Returns average loss and list of logits

--- a/pretraining.py
+++ b/pretraining.py
@@ -48,6 +48,21 @@ class CustomTrainer(Trainer):
             return loss.detach() / self.args.gradient_accumulation_steps
 
 # compute metrics do not work properly at the moment, because the first n tokens, i.e memory tokens are decoded and taken into account in evaluation.
+def collate_batch(batch):
+    ret = {}
+    for key in batch[0]:
+        if isinstance(batch[0][key], dict):
+            ret[key] = {
+                subk: torch.stack([torch.tensor(item[key][subk]) for item in batch])
+                for subk in batch[0][key]
+            }
+        elif 'text' not in key:
+            ret[key] = torch.stack([torch.tensor(item[key]) for item in batch])
+        else:
+            ret[key] = [item[key] for item in batch]
+    return ret
+
+
 def compute_metrics(eval_pred, model, rouge):
     logits, labels = eval_pred
     if isinstance(logits, tuple):  # Check if logits are wrapped in a tuple
@@ -101,19 +116,38 @@ def get_args():
     args = parser.parse_args()
     return args
 
-def pretrain_tokenize_function(examples,
-                                compressor_tokenizer,
-                                decoder_tokenizer,
-                                tc_ratio=0.0,
-                                compression_rate=1,
-                                max_len=512):
+def pretrain_tokenize_function(
+    examples,
+    compressor_tokenizer,
+    decoder_tokenizer,
+    tc_ratio=0.0,
+    compression_rates=None,
+    max_len=512,
+):
 
-        ae = random.random() >= tc_ratio
-        if ae:
-            training_input = prepare_auto_encoding(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, max_len, train=True)
-        else:
-            training_input  = prepare_text_continuation(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, max_len, train=True)
-        return training_input
+    if compression_rates is None:
+        compression_rates = [1]
+
+    ae = random.random() >= tc_ratio
+    if ae:
+        training_input = prepare_auto_encoding(
+            examples,
+            compressor_tokenizer,
+            decoder_tokenizer,
+            compression_rates,
+            max_len,
+            train=True,
+        )
+    else:
+        training_input = prepare_text_continuation(
+            examples,
+            compressor_tokenizer,
+            decoder_tokenizer,
+            compression_rates,
+            max_len,
+            train=True,
+        )
+    return training_input
 
 
 
@@ -163,13 +197,20 @@ def main():
     dataset['test'] = dataset['test'].select(range(64))
 
 
-    dataset = dataset.map(pretrain_tokenize_function, num_proc=num_proc, batched=True,
-                                            fn_kwargs={"compressor_tokenizer": model.compr.tokenizer if model.compr else model.decoder_tokenizer,
-                                                        "decoder_tokenizer": model.decoder_tokenizer,
-                                                        "tc_ratio": args.tc_ratio,
-                                                        "max_len": args.doc_max_length,
-                                                        "compression_rate": args.compression_rate}
-                                                        )
+    dataset = dataset.map(
+        pretrain_tokenize_function,
+        num_proc=num_proc,
+        batched=True,
+        fn_kwargs={
+            "compressor_tokenizer": model.compr.tokenizer if model.compr else model.decoder_tokenizer,
+            "decoder_tokenizer": model.decoder_tokenizer,
+            "tc_ratio": args.tc_ratio,
+            "max_len": args.doc_max_length,
+            "compression_rates": [args.compression_rate]
+            if isinstance(args.compression_rate, int)
+            else args.compression_rate,
+        },
+    )
 
     dataset['train'] = dataset['train'].shuffle(seed=42)
 
@@ -213,7 +254,8 @@ def main():
         args=training_args,
         train_dataset=dataset['train'],
         eval_dataset=dataset['test'],
-        compute_metrics=lambda e: compute_metrics(e, model=model, rouge=rouge)
+        compute_metrics=lambda e: compute_metrics(e, model=model, rouge=rouge),
+        data_collator=collate_batch,
     )
 
     trainer.create_optimizer_and_scheduler(num_training_steps=total_steps)

--- a/test.py
+++ b/test.py
@@ -25,7 +25,13 @@ def get_args():
 def collate_batch(batch):
     return_dict = {}
     for key in batch[0]:
-        if 'text' not in key:
+        if isinstance(batch[0][key], dict):
+            # handle nested dictionaries for different compression rates
+            return_dict[key] = {
+                subk: torch.stack([torch.tensor(item[key][subk]) for item in batch])
+                for subk in batch[0][key]
+            }
+        elif 'text' not in key:
             return_dict[key] = torch.stack([torch.tensor(item[key]) for item in batch])
         else:
             return_dict[key] = [item[key] for item in batch]
@@ -68,14 +74,18 @@ def main():
             print(f'File {out_file} exists. Skipping')
             continue
         print(f'Testing on {args.num_test_examples} examples.')
-        dataset_task = dataset.map(pretrain_tokenize_function, batched=True, load_from_cache_file=False,
-                                            fn_kwargs={"compressor_tokenizer": model.compr.tokenizer if model.compr else model.decoder_tokenizer,
-                                                        "decoder_tokenizer": model.decoder_tokenizer,
-                                                        "enc_max_len": args.doc_max_length,
-                                                        "compression_rate": model.compr_rate,
-                                                        'train': False,
-                                                        }
-                                                        )
+        dataset_task = dataset.map(
+            pretrain_tokenize_function,
+            batched=True,
+            load_from_cache_file=False,
+            fn_kwargs={
+                "compressor_tokenizer": model.compr.tokenizer if model.compr else model.decoder_tokenizer,
+                "decoder_tokenizer": model.decoder_tokenizer,
+                "enc_max_len": args.doc_max_length,
+                "compression_rates": [model.current_rate],
+                "train": False,
+            },
+        )
         
         dataloader = torch.utils.data.DataLoader(dataset_task, args.batch_size, collate_fn=collate_batch)
         model.eval()
@@ -84,6 +94,12 @@ def main():
         for batch in tqdm(dataloader):
             text = batch.pop('text')
             next_text = batch.pop('next_text')
+            if isinstance(batch['dec_input_ids'], dict):
+                key = list(batch['dec_input_ids'].keys())[0]
+                batch['dec_input_ids'] = batch['dec_input_ids'][key]
+                batch['dec_attention_mask'] = batch['dec_attention_mask'][key]
+                if 'labels' in batch:
+                    batch['labels'] = batch['labels'][key]
             pred = model.generate(batch, max_new_tokens=256)
             preds += pred
             next_texts += next_text

--- a/train.py
+++ b/train.py
@@ -52,6 +52,21 @@ class CustomTrainer(Trainer):
         return (loss, outputs) if return_outputs else loss
 
 
+def collate_batch(batch):
+    ret = {}
+    for key in batch[0]:
+        if isinstance(batch[0][key], dict):
+            ret[key] = {
+                subk: torch.stack([torch.tensor(item[key][subk]) for item in batch])
+                for subk in batch[0][key]
+            }
+        elif 'text' not in key:
+            ret[key] = torch.stack([torch.tensor(item[key]) for item in batch])
+        else:
+            ret[key] = [item[key] for item in batch]
+    return ret
+
+
 def compute_metrics(eval_pred, model, rouge):
     # Handle multiple logits from different compression rates
     logits_list, labels = eval_pred
@@ -84,25 +99,37 @@ def compute_metrics(eval_pred, model, rouge):
     return metrics
 
 
-def pretrain_tokenize_function(examples,
-                               compressor_tokenizer,
-                               decoder_tokenizer,
-                               tc_ratio=0.0,
-                               compression_rates=[],  # Now accepts list
-                               max_len=512):
+def pretrain_tokenize_function(
+    examples,
+    compressor_tokenizer,
+    decoder_tokenizer,
+    tc_ratio=0.0,
+    compression_rates=None,
+    max_len=512,
+):
 
+    if compression_rates is None:
+        compression_rates = [1]
 
     ae = random.random() >= tc_ratio
-    # For multiple compression rates, we'll use the first one for tokenization
-    # since the actual compression happens in the model
-    compression_rate = compression_rates[0] if isinstance(compression_rates, list) else compression_rates
-
     if ae:
-        return prepare_auto_encoding(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, max_len,
-                                     train=True)
+        return prepare_auto_encoding(
+            examples,
+            compressor_tokenizer,
+            decoder_tokenizer,
+            compression_rates,
+            max_len,
+            train=True,
+        )
     else:
-        return prepare_text_continuation(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, max_len,
-                                         train=True)
+        return prepare_text_continuation(
+            examples,
+            compressor_tokenizer,
+            decoder_tokenizer,
+            compression_rates,
+            max_len,
+            train=True,
+        )
 
 
 def main():
@@ -222,7 +249,8 @@ def main():
         args=training_args,
         train_dataset=dataset['train'],
         eval_dataset=dataset['test'],
-        compute_metrics=lambda e: compute_metrics(e, model=model, rouge=rouge)
+        compute_metrics=lambda e: compute_metrics(e, model=model, rouge=rouge),
+        data_collator=collate_batch,
     )
 
     trainer.create_optimizer_and_scheduler(num_training_steps=total_steps)

--- a/train_cmab.py
+++ b/train_cmab.py
@@ -17,7 +17,12 @@ from utils import prepare_auto_encoding
 def collate_batch(batch):
     ret = {}
     for key in batch[0]:
-        if 'text' not in key:
+        if isinstance(batch[0][key], dict):
+            ret[key] = {
+                subk: torch.stack([torch.tensor(item[key][subk]) for item in batch])
+                for subk in batch[0][key]
+            }
+        elif 'text' not in key:
             ret[key] = torch.stack([torch.tensor(item[key]) for item in batch])
         else:
             ret[key] = [item[key] for item in batch]
@@ -84,7 +89,7 @@ def main():
             fn_kwargs={
                 "compressor_tokenizer": model.compr.tokenizer if model.compr else model.decoder_tokenizer,
                 "decoder_tokenizer": model.decoder_tokenizer,
-                "compression_rate": rate,
+                "compression_rates": [rate],
                 "enc_max_len": args.doc_max_length,
                 "train": False,
             },

--- a/utils.py
+++ b/utils.py
@@ -2,85 +2,202 @@ import torch
 import random
 import math
 
-def prepare_auto_encoding(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, enc_max_len, train=True):
-    # auto-encoding 
-    # input for compression
-    num_embeds = math.ceil(enc_max_len / compression_rate)
-    if compressor_tokenizer ==  decoder_tokenizer:
-        inp_enc_text = [ decoder_tokenizer.enc_token +  decoder_tokenizer.bos_token + text + decoder_tokenizer.eos_token for text in examples['text']]
-        inp_enc = compressor_tokenizer(inp_enc_text, return_tensors='pt', padding='max_length', max_length=enc_max_len + 3, truncation=True, add_special_tokens=False)
-        mem_tokens = torch.full((inp_enc['input_ids'].size(0), num_embeds), decoder_tokenizer.mem_token_id, dtype=torch.long)
-        inp_enc['input_ids'] = torch.cat([inp_enc['input_ids'], mem_tokens], dim=1)
-        inp_enc['attention_mask'] = torch.cat([inp_enc['attention_mask'], torch.ones(inp_enc['input_ids'].size(0), num_embeds)], dim=1)
-        
+def _prepare_decoder_inputs(examples, decoder_tokenizer, num_embeds, task="ae", train=True):
+    """Helper to create decoder inputs/labels for a given number of <MEM> tokens."""
+
+    if task == "ae":
+        prefix = decoder_tokenizer.ae_token + decoder_tokenizer.bos_token
+        texts = examples["text"]
     else:
-        inp_enc = compressor_tokenizer(examples['text'], return_tensors='pt', padding='max_length', max_length=enc_max_len, truncation=True)
+        prefix = decoder_tokenizer.bos_token
+        texts = examples["next_text"]
+
+    instr = [
+        prefix + decoder_tokenizer.mem_token * num_embeds + text + decoder_tokenizer.eos_token
+        for text in texts
+    ]
 
     dec_max_length = 3 + num_embeds + 128
-    inp_dec = [decoder_tokenizer.ae_token + decoder_tokenizer.bos_token + decoder_tokenizer.mem_token * num_embeds + text + decoder_tokenizer.eos_token for text in examples['text']]
-    inp_dec = decoder_tokenizer(inp_dec, return_tensors='pt', padding='max_length', add_special_tokens=False, max_length=dec_max_length, truncation=True)
+    inp_dec = decoder_tokenizer(
+        instr,
+        return_tensors="pt",
+        padding="max_length",
+        add_special_tokens=False,
+        max_length=dec_max_length,
+        truncation=True,
+    )
 
-    labels = inp_dec['input_ids'].clone()
-
+    labels = inp_dec["input_ids"].clone()
     labels[labels == decoder_tokenizer.pad_token_id] = -100
     if decoder_tokenizer.bos_token_id != decoder_tokenizer.pad_token_id:
         labels[labels == decoder_tokenizer.bos_token_id] = -100
     labels[labels == decoder_tokenizer.mem_token_id] = -100
-    labels[labels == decoder_tokenizer.ae_token_id] = -100
+    if task == "ae":
+        labels[labels == decoder_tokenizer.ae_token_id] = -100
 
     if not train:
-        instr = [decoder_tokenizer.ae_token + decoder_tokenizer.bos_token + decoder_tokenizer.mem_token * num_embeds for i in range(len(examples['text']))]
-        inp_dec = decoder_tokenizer(instr, return_tensors='pt', padding="longest",  max_length=dec_max_length, add_special_tokens=False,truncation=True)
+        if task == "ae":
+            prompt = [
+                decoder_tokenizer.ae_token
+                + decoder_tokenizer.bos_token
+                + decoder_tokenizer.mem_token * num_embeds
+                for _ in range(len(texts))
+            ]
+        else:
+            prompt = [
+                decoder_tokenizer.bos_token
+                + decoder_tokenizer.mem_token * num_embeds
+                for _ in range(len(texts))
+            ]
+        inp_dec = decoder_tokenizer(
+            prompt,
+            return_tensors="pt",
+            padding="longest",
+            add_special_tokens=False,
+            truncation=True,
+        )
 
-    enc_attention_mask, enc_input_ids = inp_enc['attention_mask'], inp_enc['input_ids']
-    dec_attention_mask, dec_input_ids = inp_dec['attention_mask'], inp_dec['input_ids']
+    return inp_dec["input_ids"], inp_dec["attention_mask"], labels
 
-    return {
-        'enc_input_ids': enc_input_ids,
-        'enc_attention_mask': enc_attention_mask,
-        'dec_input_ids': dec_input_ids,
-        'dec_attention_mask': dec_attention_mask,
-        'labels': labels
-    }
 
-def prepare_text_continuation( examples, compressor_tokenizer, decoder_tokenizer, compression_rate, enc_max_len, train=True):
-    # text continuation
-    # input for text continuation
-    num_embeds = math.ceil(enc_max_len / compression_rate)
+def prepare_auto_encoding(
+    examples,
+    compressor_tokenizer,
+    decoder_tokenizer,
+    compression_rates,
+    enc_max_len,
+    train=True,
+):
+    """Prepare inputs for auto-encoding across multiple compression rates."""
+
+    if not isinstance(compression_rates, (list, tuple)):
+        compression_rates = [compression_rates]
+
+    num_embeds = {r: math.ceil(enc_max_len / r) for r in compression_rates}
 
     if compressor_tokenizer == decoder_tokenizer:
-        inp_enc_text = [ decoder_tokenizer.enc_token +  decoder_tokenizer.bos_token + text + decoder_tokenizer.eos_token for text in examples['text']]
-        inp_enc = compressor_tokenizer(inp_enc_text, return_tensors='pt', padding='max_length', max_length=enc_max_len + 3, truncation=True, add_special_tokens=False)
-        mem_tokens = torch.full((inp_enc['input_ids'].size(0), num_embeds), decoder_tokenizer.mem_token_id, dtype=torch.long)
-        inp_enc['input_ids'] = torch.cat([inp_enc['input_ids'], mem_tokens], dim=1)
-        inp_enc['attention_mask'] = torch.cat([inp_enc['attention_mask'], torch.ones(inp_enc['input_ids'].size(0), num_embeds)], dim=1)
+        max_mem = max(num_embeds.values())
+        inp_enc_text = [
+            decoder_tokenizer.enc_token
+            + decoder_tokenizer.bos_token
+            + text
+            + decoder_tokenizer.eos_token
+            for text in examples["text"]
+        ]
+        inp_enc = compressor_tokenizer(
+            inp_enc_text,
+            return_tensors="pt",
+            padding="max_length",
+            max_length=enc_max_len + 3,
+            truncation=True,
+            add_special_tokens=False,
+        )
+        mem_tokens = torch.full(
+            (inp_enc["input_ids"].size(0), max_mem),
+            decoder_tokenizer.mem_token_id,
+            dtype=torch.long,
+        )
+        inp_enc["input_ids"] = torch.cat([inp_enc["input_ids"], mem_tokens], dim=1)
+        inp_enc["attention_mask"] = torch.cat(
+            [inp_enc["attention_mask"], torch.ones(inp_enc["input_ids"].size(0), max_mem)],
+            dim=1,
+        )
     else:
-        inp_enc = compressor_tokenizer(examples['text'], return_tensors='pt', padding='max_length', max_length=enc_max_len, truncation=True)
+        inp_enc = compressor_tokenizer(
+            examples["text"],
+            return_tensors="pt",
+            padding="max_length",
+            max_length=enc_max_len,
+            truncation=True,
+        )
 
-    dec_max_length = 3 + num_embeds + 128
-    inp_dec = [decoder_tokenizer.bos_token + decoder_tokenizer.mem_token * num_embeds + text + decoder_tokenizer.eos_token for text in examples['next_text']]
-    inp_dec = decoder_tokenizer(inp_dec, return_tensors='pt', padding='max_length', truncation=True, max_length=dec_max_length)
-
-    labels = inp_dec['input_ids'].clone()
-    labels[labels == decoder_tokenizer.pad_token_id] = -100
-    if decoder_tokenizer.bos_token_id != decoder_tokenizer.pad_token_id:
-        labels[labels == decoder_tokenizer.bos_token_id] = -100
-    labels[labels == decoder_tokenizer.mem_token_id] = -100
-
-
-
-    if not train:
-        instr = [decoder_tokenizer.bos_token + decoder_tokenizer.mem_token * num_embeds for i in range(len(examples['text']))]
-        inp_dec = decoder_tokenizer(instr, return_tensors='pt', padding="longest", add_special_tokens=False,truncation=True)
-        
-    enc_attention_mask, enc_input_ids = inp_enc['attention_mask'], inp_enc['input_ids']
-    dec_attention_mask, dec_input_ids = inp_dec['attention_mask'], inp_dec['input_ids']
+    dec_input_ids = {}
+    dec_attention_mask = {}
+    labels = {}
+    for r, n_mem in num_embeds.items():
+        ids, mask, lab = _prepare_decoder_inputs(
+            examples, decoder_tokenizer, n_mem, task="ae", train=train
+        )
+        dec_input_ids[r] = ids
+        dec_attention_mask[r] = mask
+        labels[r] = lab
 
     return {
-        'enc_input_ids': enc_input_ids,
-        'enc_attention_mask': enc_attention_mask,
-        'dec_input_ids': dec_input_ids,
-        'dec_attention_mask': dec_attention_mask,
-        'labels': labels
+        "enc_input_ids": inp_enc["input_ids"],
+        "enc_attention_mask": inp_enc["attention_mask"],
+        "dec_input_ids": dec_input_ids,
+        "dec_attention_mask": dec_attention_mask,
+        "labels": labels,
+    }
+
+
+def prepare_text_continuation(
+    examples,
+    compressor_tokenizer,
+    decoder_tokenizer,
+    compression_rates,
+    enc_max_len,
+    train=True,
+):
+    """Prepare inputs for text-continuation across multiple compression rates."""
+
+    if not isinstance(compression_rates, (list, tuple)):
+        compression_rates = [compression_rates]
+
+    num_embeds = {r: math.ceil(enc_max_len / r) for r in compression_rates}
+
+    if compressor_tokenizer == decoder_tokenizer:
+        max_mem = max(num_embeds.values())
+        inp_enc_text = [
+            decoder_tokenizer.enc_token
+            + decoder_tokenizer.bos_token
+            + text
+            + decoder_tokenizer.eos_token
+            for text in examples["text"]
+        ]
+        inp_enc = compressor_tokenizer(
+            inp_enc_text,
+            return_tensors="pt",
+            padding="max_length",
+            max_length=enc_max_len + 3,
+            truncation=True,
+            add_special_tokens=False,
+        )
+        mem_tokens = torch.full(
+            (inp_enc["input_ids"].size(0), max_mem),
+            decoder_tokenizer.mem_token_id,
+            dtype=torch.long,
+        )
+        inp_enc["input_ids"] = torch.cat([inp_enc["input_ids"], mem_tokens], dim=1)
+        inp_enc["attention_mask"] = torch.cat(
+            [inp_enc["attention_mask"], torch.ones(inp_enc["input_ids"].size(0), max_mem)],
+            dim=1,
+        )
+    else:
+        inp_enc = compressor_tokenizer(
+            examples["text"],
+            return_tensors="pt",
+            padding="max_length",
+            max_length=enc_max_len,
+            truncation=True,
+        )
+
+    dec_input_ids = {}
+    dec_attention_mask = {}
+    labels = {}
+    for r, n_mem in num_embeds.items():
+        ids, mask, lab = _prepare_decoder_inputs(
+            examples, decoder_tokenizer, n_mem, task="tc", train=train
+        )
+        dec_input_ids[r] = ids
+        dec_attention_mask[r] = mask
+        labels[r] = lab
+
+    return {
+        "enc_input_ids": inp_enc["input_ids"],
+        "enc_attention_mask": inp_enc["attention_mask"],
+        "dec_input_ids": dec_input_ids,
+        "dec_attention_mask": dec_attention_mask,
+        "labels": labels,
     }
 


### PR DESCRIPTION
## Summary
- Add collate functions to stack rate-specific decoder inputs for training and pretraining
- Pass custom collators to Trainers so batches return compression-rate keyed tensors
- Update evaluation script to select the current rate and unwrap its decoder inputs before generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5bdc30a48324b4948e5267012320