### PR TITLE
Refactor preprocessing for multi-rate decoder inputs

### DIFF
--- a/pretraining.py
+++ b/pretraining.py
@@ -105,14 +105,28 @@ def pretrain_tokenize_function(examples,
                                 compressor_tokenizer,
                                 decoder_tokenizer,
                                 tc_ratio=0.0,
-                                compression_rate=1,
+                                compression_rates=1,
                                 max_len=512):
 
         ae = random.random() >= tc_ratio
         if ae:
-            training_input = prepare_auto_encoding(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, max_len, train=True)
+            training_input = prepare_auto_encoding(
+                examples,
+                compressor_tokenizer,
+                decoder_tokenizer,
+                compression_rates,
+                max_len,
+                train=True,
+            )
         else:
-            training_input  = prepare_text_continuation(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, max_len, train=True)
+            training_input = prepare_text_continuation(
+                examples,
+                compressor_tokenizer,
+                decoder_tokenizer,
+                compression_rates,
+                max_len,
+                train=True,
+            )
         return training_input
 
 
@@ -147,7 +161,7 @@ def main():
         generation_top_k=1,
         sep=False,
         compr_model_name=args.compressor_model_name,
-        compr_rate=args.compression_rate,
+        compr_rates=[args.compression_rate],
         compr_linear_type=args.compression_linear_type,
         lora=lora,
     )
@@ -163,23 +177,48 @@ def main():
     dataset['test'] = dataset['test'].select(range(64))
 
 
-    dataset = dataset.map(pretrain_tokenize_function, num_proc=num_proc, batched=True,
-                                            fn_kwargs={"compressor_tokenizer": model.compr.tokenizer if model.compr else model.decoder_tokenizer,
-                                                        "decoder_tokenizer": model.decoder_tokenizer,
-                                                        "tc_ratio": args.tc_ratio,
-                                                        "max_len": args.doc_max_length,
-                                                        "compression_rate": args.compression_rate}
-                                                        )
+    dataset = dataset.map(
+        pretrain_tokenize_function,
+        num_proc=num_proc,
+        batched=True,
+        fn_kwargs={
+            "compressor_tokenizer": model.compr.tokenizer if model.compr else model.decoder_tokenizer,
+            "decoder_tokenizer": model.decoder_tokenizer,
+            "tc_ratio": args.tc_ratio,
+            "max_len": args.doc_max_length,
+            "compression_rates": [args.compression_rate],
+        },
+    )
 
     dataset['train'] = dataset['train'].shuffle(seed=42)
 
-
+    def collate_batch(batch):
+        enc_input_ids = torch.stack([item['enc_input_ids'] for item in batch])
+        enc_attention_mask = torch.stack([item['enc_attention_mask'] for item in batch])
+        collated = {
+            'enc_input_ids': enc_input_ids,
+            'enc_attention_mask': enc_attention_mask,
+            'dec_input_ids': {},
+            'dec_attention_mask': {},
+            'labels': {}
+        }
+        # Only a single compression rate is used in this script
+        for rate in [args.compression_rate]:
+            collated['dec_input_ids'][rate] = torch.stack(
+                [item[f'dec_input_ids_{rate}'] for item in batch]
+            )
+            collated['dec_attention_mask'][rate] = torch.stack(
+                [item[f'dec_attention_mask_{rate}'] for item in batch]
+            )
+            collated['labels'][rate] = torch.stack(
+                [item[f'labels_{rate}'] for item in batch]
+            )
+        return collated
 
     # for index, item in enumerate(dataset['train']):
     #     validate_data_item(item)
         # if index > 100:  # Limit to first 100 items for quick checking
         #     break
-
 
     training_args = TrainingArguments(
         output_dir=model_output_dir,
@@ -213,6 +252,7 @@ def main():
         args=training_args,
         train_dataset=dataset['train'],
         eval_dataset=dataset['test'],
+        data_collator=collate_batch,
         compute_metrics=lambda e: compute_metrics(e, model=model, rouge=rouge)
     )
 

--- a/train.py
+++ b/train.py
@@ -88,21 +88,29 @@ def pretrain_tokenize_function(examples,
                                compressor_tokenizer,
                                decoder_tokenizer,
                                tc_ratio=0.0,
-                               compression_rates=[],  # Now accepts list
+                               compression_rates=[],  # list of compression rates
                                max_len=512):
 
-
     ae = random.random() >= tc_ratio
-    # For multiple compression rates, we'll use the first one for tokenization
-    # since the actual compression happens in the model
-    compression_rate = compression_rates[0] if isinstance(compression_rates, list) else compression_rates
 
     if ae:
-        return prepare_auto_encoding(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, max_len,
-                                     train=True)
+        return prepare_auto_encoding(
+            examples,
+            compressor_tokenizer,
+            decoder_tokenizer,
+            compression_rates,
+            max_len,
+            train=True,
+        )
     else:
-        return prepare_text_continuation(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, max_len,
-                                         train=True)
+        return prepare_text_continuation(
+            examples,
+            compressor_tokenizer,
+            decoder_tokenizer,
+            compression_rates,
+            max_len,
+            train=True,
+        )
 
 
 def main():
@@ -189,6 +197,28 @@ def main():
 
     dataset['train'] = dataset['train'].shuffle(seed=42)
 
+    def collate_batch(batch):
+        enc_input_ids = torch.stack([item['enc_input_ids'] for item in batch])
+        enc_attention_mask = torch.stack([item['enc_attention_mask'] for item in batch])
+        collated = {
+            'enc_input_ids': enc_input_ids,
+            'enc_attention_mask': enc_attention_mask,
+            'dec_input_ids': {},
+            'dec_attention_mask': {},
+            'labels': {}
+        }
+        for rate in args.compression_rates:
+            collated['dec_input_ids'][rate] = torch.stack(
+                [item[f'dec_input_ids_{rate}'] for item in batch]
+            )
+            collated['dec_attention_mask'][rate] = torch.stack(
+                [item[f'dec_attention_mask_{rate}'] for item in batch]
+            )
+            collated['labels'][rate] = torch.stack(
+                [item[f'labels_{rate}'] for item in batch]
+            )
+        return collated
+
     training_args = TrainingArguments(
         output_dir=model_output_dir,
         learning_rate=args.lr,
@@ -222,6 +252,7 @@ def main():
         args=training_args,
         train_dataset=dataset['train'],
         eval_dataset=dataset['test'],
+        data_collator=collate_batch,
         compute_metrics=lambda e: compute_metrics(e, model=model, rouge=rouge)
     )
 

--- a/utils.py
+++ b/utils.py
@@ -2,85 +2,210 @@ import torch
 import random
 import math
 
-def prepare_auto_encoding(examples, compressor_tokenizer, decoder_tokenizer, compression_rate, enc_max_len, train=True):
-    # auto-encoding 
-    # input for compression
-    num_embeds = math.ceil(enc_max_len / compression_rate)
-    if compressor_tokenizer ==  decoder_tokenizer:
-        inp_enc_text = [ decoder_tokenizer.enc_token +  decoder_tokenizer.bos_token + text + decoder_tokenizer.eos_token for text in examples['text']]
-        inp_enc = compressor_tokenizer(inp_enc_text, return_tensors='pt', padding='max_length', max_length=enc_max_len + 3, truncation=True, add_special_tokens=False)
-        mem_tokens = torch.full((inp_enc['input_ids'].size(0), num_embeds), decoder_tokenizer.mem_token_id, dtype=torch.long)
-        inp_enc['input_ids'] = torch.cat([inp_enc['input_ids'], mem_tokens], dim=1)
-        inp_enc['attention_mask'] = torch.cat([inp_enc['attention_mask'], torch.ones(inp_enc['input_ids'].size(0), num_embeds)], dim=1)
-        
-    else:
-        inp_enc = compressor_tokenizer(examples['text'], return_tensors='pt', padding='max_length', max_length=enc_max_len, truncation=True)
 
-    dec_max_length = 3 + num_embeds + 128
-    inp_dec = [decoder_tokenizer.ae_token + decoder_tokenizer.bos_token + decoder_tokenizer.mem_token * num_embeds + text + decoder_tokenizer.eos_token for text in examples['text']]
-    inp_dec = decoder_tokenizer(inp_dec, return_tensors='pt', padding='max_length', add_special_tokens=False, max_length=dec_max_length, truncation=True)
+def prepare_auto_encoding(examples, compressor_tokenizer, decoder_tokenizer, compression_rates, enc_max_len, train=True):
+    """Prepare inputs for the auto-encoding task.
 
-    labels = inp_dec['input_ids'].clone()
+    Instead of returning nested dictionaries keyed by the compression rate, this
+    function now flattens the keys so that each rate-specific tensor is stored
+    under a distinct key, e.g. ``dec_input_ids_{rate}``.
+    """
+    if not isinstance(compression_rates, (list, tuple)):
+        compression_rates = [compression_rates]
 
-    labels[labels == decoder_tokenizer.pad_token_id] = -100
-    if decoder_tokenizer.bos_token_id != decoder_tokenizer.pad_token_id:
-        labels[labels == decoder_tokenizer.bos_token_id] = -100
-    labels[labels == decoder_tokenizer.mem_token_id] = -100
-    labels[labels == decoder_tokenizer.ae_token_id] = -100
-
-    if not train:
-        instr = [decoder_tokenizer.ae_token + decoder_tokenizer.bos_token + decoder_tokenizer.mem_token * num_embeds for i in range(len(examples['text']))]
-        inp_dec = decoder_tokenizer(instr, return_tensors='pt', padding="longest",  max_length=dec_max_length, add_special_tokens=False,truncation=True)
-
-    enc_attention_mask, enc_input_ids = inp_enc['attention_mask'], inp_enc['input_ids']
-    dec_attention_mask, dec_input_ids = inp_dec['attention_mask'], inp_dec['input_ids']
-
-    return {
-        'enc_input_ids': enc_input_ids,
-        'enc_attention_mask': enc_attention_mask,
-        'dec_input_ids': dec_input_ids,
-        'dec_attention_mask': dec_attention_mask,
-        'labels': labels
-    }
-
-def prepare_text_continuation( examples, compressor_tokenizer, decoder_tokenizer, compression_rate, enc_max_len, train=True):
-    # text continuation
-    # input for text continuation
-    num_embeds = math.ceil(enc_max_len / compression_rate)
+    # Use the smallest rate to determine the maximum number of <MEM> tokens the
+    # encoder needs to allocate.
+    min_rate = min(compression_rates)
+    num_enc_mem = math.ceil(enc_max_len / min_rate)
 
     if compressor_tokenizer == decoder_tokenizer:
-        inp_enc_text = [ decoder_tokenizer.enc_token +  decoder_tokenizer.bos_token + text + decoder_tokenizer.eos_token for text in examples['text']]
-        inp_enc = compressor_tokenizer(inp_enc_text, return_tensors='pt', padding='max_length', max_length=enc_max_len + 3, truncation=True, add_special_tokens=False)
-        mem_tokens = torch.full((inp_enc['input_ids'].size(0), num_embeds), decoder_tokenizer.mem_token_id, dtype=torch.long)
-        inp_enc['input_ids'] = torch.cat([inp_enc['input_ids'], mem_tokens], dim=1)
-        inp_enc['attention_mask'] = torch.cat([inp_enc['attention_mask'], torch.ones(inp_enc['input_ids'].size(0), num_embeds)], dim=1)
+        inp_enc_text = [
+            decoder_tokenizer.enc_token
+            + decoder_tokenizer.bos_token
+            + text
+            + decoder_tokenizer.eos_token
+            for text in examples["text"]
+        ]
+        inp_enc = compressor_tokenizer(
+            inp_enc_text,
+            return_tensors="pt",
+            padding="max_length",
+            max_length=enc_max_len + 3,
+            truncation=True,
+            add_special_tokens=False,
+        )
+        mem_tokens = torch.full(
+            (inp_enc["input_ids"].size(0), num_enc_mem),
+            decoder_tokenizer.mem_token_id,
+            dtype=torch.long,
+        )
+        inp_enc["input_ids"] = torch.cat([inp_enc["input_ids"], mem_tokens], dim=1)
+        inp_enc["attention_mask"] = torch.cat(
+            [
+                inp_enc["attention_mask"],
+                torch.ones(inp_enc["input_ids"].size(0), num_enc_mem),
+            ],
+            dim=1,
+        )
+
     else:
-        inp_enc = compressor_tokenizer(examples['text'], return_tensors='pt', padding='max_length', max_length=enc_max_len, truncation=True)
+        inp_enc = compressor_tokenizer(
+            examples["text"],
+            return_tensors="pt",
+            padding="max_length",
+            max_length=enc_max_len,
+            truncation=True,
+        )
 
-    dec_max_length = 3 + num_embeds + 128
-    inp_dec = [decoder_tokenizer.bos_token + decoder_tokenizer.mem_token * num_embeds + text + decoder_tokenizer.eos_token for text in examples['next_text']]
-    inp_dec = decoder_tokenizer(inp_dec, return_tensors='pt', padding='max_length', truncation=True, max_length=dec_max_length)
-
-    labels = inp_dec['input_ids'].clone()
-    labels[labels == decoder_tokenizer.pad_token_id] = -100
-    if decoder_tokenizer.bos_token_id != decoder_tokenizer.pad_token_id:
-        labels[labels == decoder_tokenizer.bos_token_id] = -100
-    labels[labels == decoder_tokenizer.mem_token_id] = -100
-
-
-
-    if not train:
-        instr = [decoder_tokenizer.bos_token + decoder_tokenizer.mem_token * num_embeds for i in range(len(examples['text']))]
-        inp_dec = decoder_tokenizer(instr, return_tensors='pt', padding="longest", add_special_tokens=False,truncation=True)
-        
-    enc_attention_mask, enc_input_ids = inp_enc['attention_mask'], inp_enc['input_ids']
-    dec_attention_mask, dec_input_ids = inp_dec['attention_mask'], inp_dec['input_ids']
-
-    return {
-        'enc_input_ids': enc_input_ids,
-        'enc_attention_mask': enc_attention_mask,
-        'dec_input_ids': dec_input_ids,
-        'dec_attention_mask': dec_attention_mask,
-        'labels': labels
+    result = {
+        "enc_input_ids": inp_enc["input_ids"],
+        "enc_attention_mask": inp_enc["attention_mask"],
     }
+
+    for rate in compression_rates:
+        num_embeds = math.ceil(enc_max_len / rate)
+        dec_max_length = 3 + num_embeds + 128
+
+        inp_dec_text = [
+            decoder_tokenizer.ae_token
+            + decoder_tokenizer.bos_token
+            + decoder_tokenizer.mem_token * num_embeds
+            + text
+            + decoder_tokenizer.eos_token
+            for text in examples["text"]
+        ]
+        inp_dec = decoder_tokenizer(
+            inp_dec_text,
+            return_tensors="pt",
+            padding="max_length",
+            add_special_tokens=False,
+            max_length=dec_max_length,
+            truncation=True,
+        )
+
+        labels = inp_dec["input_ids"].clone()
+        labels[labels == decoder_tokenizer.pad_token_id] = -100
+        if decoder_tokenizer.bos_token_id != decoder_tokenizer.pad_token_id:
+            labels[labels == decoder_tokenizer.bos_token_id] = -100
+        labels[labels == decoder_tokenizer.mem_token_id] = -100
+        labels[labels == decoder_tokenizer.ae_token_id] = -100
+
+        if not train:
+            instr = [
+                decoder_tokenizer.ae_token
+                + decoder_tokenizer.bos_token
+                + decoder_tokenizer.mem_token * num_embeds
+                for _ in range(len(examples["text"]))
+            ]
+            inp_dec = decoder_tokenizer(
+                instr,
+                return_tensors="pt",
+                padding="longest",
+                max_length=dec_max_length,
+                add_special_tokens=False,
+                truncation=True,
+            )
+
+        result[f"dec_input_ids_{rate}"] = inp_dec["input_ids"]
+        result[f"dec_attention_mask_{rate}"] = inp_dec["attention_mask"]
+        result[f"labels_{rate}"] = labels
+
+    return result
+
+
+def prepare_text_continuation(examples, compressor_tokenizer, decoder_tokenizer, compression_rates, enc_max_len, train=True):
+    """Prepare inputs for the text-continuation task with flattened keys."""
+    if not isinstance(compression_rates, (list, tuple)):
+        compression_rates = [compression_rates]
+
+    min_rate = min(compression_rates)
+    num_enc_mem = math.ceil(enc_max_len / min_rate)
+
+    if compressor_tokenizer == decoder_tokenizer:
+        inp_enc_text = [
+            decoder_tokenizer.enc_token
+            + decoder_tokenizer.bos_token
+            + text
+            + decoder_tokenizer.eos_token
+            for text in examples["text"]
+        ]
+        inp_enc = compressor_tokenizer(
+            inp_enc_text,
+            return_tensors="pt",
+            padding="max_length",
+            max_length=enc_max_len + 3,
+            truncation=True,
+            add_special_tokens=False,
+        )
+        mem_tokens = torch.full(
+            (inp_enc["input_ids"].size(0), num_enc_mem),
+            decoder_tokenizer.mem_token_id,
+            dtype=torch.long,
+        )
+        inp_enc["input_ids"] = torch.cat([inp_enc["input_ids"], mem_tokens], dim=1)
+        inp_enc["attention_mask"] = torch.cat(
+            [
+                inp_enc["attention_mask"],
+                torch.ones(inp_enc["input_ids"].size(0), num_enc_mem),
+            ],
+            dim=1,
+        )
+    else:
+        inp_enc = compressor_tokenizer(
+            examples["text"],
+            return_tensors="pt",
+            padding="max_length",
+            max_length=enc_max_len,
+            truncation=True,
+        )
+
+    result = {
+        "enc_input_ids": inp_enc["input_ids"],
+        "enc_attention_mask": inp_enc["attention_mask"],
+    }
+
+    for rate in compression_rates:
+        num_embeds = math.ceil(enc_max_len / rate)
+        dec_max_length = 3 + num_embeds + 128
+
+        inp_dec_text = [
+            decoder_tokenizer.bos_token
+            + decoder_tokenizer.mem_token * num_embeds
+            + text
+            + decoder_tokenizer.eos_token
+            for text in examples["next_text"]
+        ]
+        inp_dec = decoder_tokenizer(
+            inp_dec_text,
+            return_tensors="pt",
+            padding="max_length",
+            truncation=True,
+            max_length=dec_max_length,
+        )
+
+        labels = inp_dec["input_ids"].clone()
+        labels[labels == decoder_tokenizer.pad_token_id] = -100
+        if decoder_tokenizer.bos_token_id != decoder_tokenizer.pad_token_id:
+            labels[labels == decoder_tokenizer.bos_token_id] = -100
+        labels[labels == decoder_tokenizer.mem_token_id] = -100
+
+        if not train:
+            instr = [
+                decoder_tokenizer.bos_token
+                + decoder_tokenizer.mem_token * num_embeds
+                for _ in range(len(examples["text"]))
+            ]
+            inp_dec = decoder_tokenizer(
+                instr,
+                return_tensors="pt",
+                padding="longest",
+                add_special_tokens=False,
+                truncation=True,
+            )
+
+        result[f"dec_input_ids_{rate}"] = inp_dec["input_ids"]
+        result[f"dec_attention_mask_{rate}"] = inp_dec["attention_mask"]
+        result[f"labels_{rate}"] = labels
+
+    return result
 


### PR DESCRIPTION
## Summary
- Flatten decoder-side features in `prepare_auto_encoding` and `prepare_text_continuation` so each compression rate outputs keys like `dec_input_ids_<rate>`
- Reconstruct rate-keyed dictionaries in custom `collate_batch` for `train.py` and `pretraining.py`
- Preserve masking of `<MEM>` tokens during refactor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5458abd408324a111d9dc74164ecb