### PR TITLE
Use perplexity for bandit context

### DIFF
--- a/cmab_agent.py
+++ b/cmab_agent.py
@@ -13,21 +13,22 @@ class CompressionBanditAgent:
         self.A = {r: np.identity(1) for r in self.rates}
         self.b = {r: np.zeros((1, 1)) for r in self.rates}
 
-    def _feat(self, entropy: float) -> np.ndarray:
-        return np.array([[entropy]], dtype=float)
+    def _feat(self, perplexity: float) -> np.ndarray:
+        return np.array([[perplexity]], dtype=float)
 
-    def select_rate(self, entropy: float) -> int:
-        x = self._feat(entropy)
+    def select_rate(self, perplexity: float) -> int:
+        x = self._feat(perplexity)
         scores = {}
         for r in self.rates:
             A_inv = np.linalg.inv(self.A[r])
             theta = A_inv @ self.b[r]
+            print(f"Rate {r} theta: {theta.ravel()[0]:.4f}")
             p = float(theta.T @ x + self.alpha * math.sqrt(x.T @ A_inv @ x))
             scores[r] = p
         return max(self.rates, key=lambda r: scores[r])
 
-    def update(self, entropy: float, rate: int, reward: float) -> None:
-        x = self._feat(entropy)
+    def update(self, perplexity: float, rate: int, reward: float) -> None:
+        x = self._feat(perplexity)
         self.A[rate] += x @ x.T
         self.b[rate] += reward * x
 
@@ -69,7 +70,11 @@ def batch_perplexity(model, input_ids, attention_mask) -> List[float]:
         for ids, mask in zip(input_ids, attention_mask):
             ids = ids.to(device)
             mask = mask.to(device)
-            outputs = model(input_ids=ids.unsqueeze(0), attention_mask=mask.unsqueeze(0), labels=ids.unsqueeze(0))
+            outputs = model(
+                input_ids=ids.unsqueeze(0),
+                attention_mask=mask.unsqueeze(0),
+                labels=ids.unsqueeze(0),
+            )
             loss = outputs.loss
             perplexities.append(float(math.exp(loss.item())))
     return perplexities

--- a/cmab_agent.py
+++ b/cmab_agent.py
@@ -50,8 +50,9 @@ def batch_perplexity(model, input_ids, attention_mask) -> List[float]:
 
     Parameters
     ----------
-    model : transformers.PreTrainedModel
-        Language model used to compute the likelihood of the documents.
+    model : transformers.PreTrainedModel or COCOM
+        Language model used to compute the likelihood of the documents. If a
+        ``COCOM`` instance is provided, its ``decoder`` will be used.
     input_ids : torch.LongTensor
         Token ids of shape ``(batch_size, seq_len)``.
     attention_mask : torch.LongTensor
@@ -63,14 +64,18 @@ def batch_perplexity(model, input_ids, attention_mask) -> List[float]:
         Perplexity score for every document.
     """
 
-    device = next(model.parameters()).device
+    # ``COCOM`` wraps a decoder model which exposes the standard causal LM
+    # interface.  If present, compute perplexity with the decoder.
+    lm = getattr(model, "decoder", model)
+
+    device = next(lm.parameters()).device
     perplexities = []
-    model.eval()
+    lm.eval()
     with torch.no_grad():
         for ids, mask in zip(input_ids, attention_mask):
             ids = ids.to(device)
             mask = mask.to(device)
-            outputs = model(
+            outputs = lm(
                 input_ids=ids.unsqueeze(0),
                 attention_mask=mask.unsqueeze(0),
                 labels=ids.unsqueeze(0),

--- a/train_cmab.py
+++ b/train_cmab.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import math
 import pickle
 import json
 import matplotlib.pyplot as plt
@@ -10,7 +9,7 @@ import torch
 from torch.utils.data import DataLoader
 import numpy as np
 from modeling_cocom import COCOM
-from cmab_agent import CompressionBanditAgent, batch_entropy
+from cmab_agent import CompressionBanditAgent, batch_perplexity
 from metrics import exact_match_score, compute_rouge_scores
 from utils import prepare_auto_encoding
 from bert_score import BERTScorer
@@ -214,25 +213,25 @@ def main():
     total_examples = 0
     for batch_idx, batch in enumerate(loader):
         texts = batch.pop("text")
-        # Compute contexts (entropy) on CPU tensors expected by batch_entropy
-        entropies = batch_entropy(batch["enc_input_ids"], batch["enc_attention_mask"])
+        # Compute contexts (perplexity) on CPU tensors expected by batch_perplexity
+        perplexities = batch_perplexity(model, batch["enc_input_ids"], batch["enc_attention_mask"])
 
-        ent_arr = np.asarray(entropies, dtype=float)
-        ent_min = float(ent_arr.min()) if ent_arr.size else float('nan')
-        ent_max = float(ent_arr.max()) if ent_arr.size else float('nan')
-        ent_mean = float(ent_arr.mean()) if ent_arr.size else float('nan')
-        ent_std = float(ent_arr.std(ddof=0)) if ent_arr.size else float('nan')
+        perp_arr = np.asarray(perplexities, dtype=float)
+        perp_min = float(perp_arr.min()) if perp_arr.size else float('nan')
+        perp_max = float(perp_arr.max()) if perp_arr.size else float('nan')
+        perp_mean = float(perp_arr.mean()) if perp_arr.size else float('nan')
+        perp_std = float(perp_arr.std(ddof=0)) if perp_arr.size else float('nan')
         print(
             f"Batch {batch_idx + 1}/{len(loader)} | "
-            f"entropy min={ent_min:.4f}, max={ent_max:.4f}, "
-            f"avg={ent_mean:.4f}, std={ent_std:.4f}"
+            f"perplexity min={perp_min:.4f}, max={perp_max:.4f}, "
+            f"avg={perp_mean:.4f}, std={perp_std:.4f}"
         )
 
         B = len(texts)
 
         # Process each example independently: select → play → update
         for i in range(B):
-            x = float(entropies[i])  # context feature (entropy); if you use d>1 features, pass a vector
+            x = float(perplexities[i])  # context feature (perplexity); if you use d>1 features, pass a vector
             # UCB arm selection (uses A_a, b_a, alpha inside the agent)
             chosen_rate = agent.select_rate(x)
 
@@ -291,7 +290,7 @@ def main():
 
     # Now attach the trained bandit for inference-time selection inside COCOM.generate()
     model.set_bandit_agent(
-        agent)  # COCOM will call agent.select_rate(...) based on entropy at generation time:contentReference[oaicite:1]{index=1}
+        agent)  # COCOM will call agent.select_rate(...) based on perplexity at generation time
 
     # Save trained agent
     os.makedirs(args.output_dir, exist_ok=True)


### PR DESCRIPTION
## Summary
- Replace entropy with perplexity as bandit context and feature.
- Print learned theta parameters during UCB rate selection.
- Log batch perplexity stats and use them in training.

## Testing
- `python -m py_compile cmab_agent.py train_cmab.py`


------
https://chatgpt.com/codex/tasks/task_e_68c26740b2bc8324a4eecec432db2595